### PR TITLE
feat: automatically retry a few times on rate limit

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -127,21 +127,37 @@ export default class Client {
     this._batchSize++;
     if (!this._batch) {
       this._batch = new Batch(async (q) => {
-        const req = {
-          query: print(q.query),
-          variables: q.variables,
-        };
-        if (this._options.onBatchRequest) this._options.onBatchRequest(req);
-        const response = await this.request({
-          ...req,
-          method: 'POST',
-          url: '/graphql',
-        });
+        let attempts = 0;
+        while (true) {
+          const req = {
+            query: print(q.query),
+            variables: q.variables,
+          };
+          if (this._options.onBatchRequest) this._options.onBatchRequest(req);
+          const response = await this.request({
+            ...req,
+            method: 'POST',
+            url: '/graphql',
+          });
 
-        if (this._options.onBatchResponse)
-          this._options.onBatchResponse(req, response);
-
-        return response.data;
+          if (this._options.onBatchResponse)
+            this._options.onBatchResponse(req, response);
+          if (
+            response.data.errors?.length === 1 &&
+            response.data.errors[0].type === 'RATE_LIMITED'
+          ) {
+            if (attempts++ > 3) {
+              const err: any = new Error('Rate limit exceeded');
+              err.code = 'RATE_LIMITED';
+              throw err;
+            }
+            await new Promise((resolve) => {
+              setTimeout(resolve, 5000);
+            });
+            continue;
+          }
+          return response.data;
+        }
       });
       void Promise.resolve(null).then(this._processQueue);
     }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -147,12 +147,10 @@ export default class Client {
             response.data.errors[0].type === 'RATE_LIMITED'
           ) {
             if (attempts++ > 3) {
-              const err: any = new Error('Rate limit exceeded');
-              err.code = 'RATE_LIMITED';
-              throw err;
+              throw new GraphqlError(req, response);
             }
             await new Promise((resolve) => {
-              setTimeout(resolve, 5000);
+              setTimeout(resolve, attempts * 5000);
             });
             continue;
           }


### PR DESCRIPTION
Then if that fails, we throw a rate limit exceeded error. This prevents us splitting the batch up to try again, which would be a diaster as it would hammer our rate limit